### PR TITLE
Only upload/delete remote file if it changed

### DIFF
--- a/examples/edit/edit.go
+++ b/examples/edit/edit.go
@@ -2,43 +2,78 @@ package main
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 
 	"github.com/adammck/remotefile"
 	s3be "github.com/adammck/remotefile/backend/s3"
+	"github.com/adammck/remotefile/iface"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
 func main() {
-	svc := s3.New(session.New())
-	f := remotefile.New(s3be.New(svc, "adammck", "remotefile/edit.txt"))
 
-	fmt.Println("downloading...")
-	_, err := f.Get()
+	if len(os.Args) != 2 {
+		fmt.Printf("usage: %s [url]\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	u, err := url.Parse(os.Args[1])
 	checkErr(err)
 
+	var be iface.Backend
+	switch u.Scheme {
+	case "s3":
+		// The S3 backend is configured via ENV
+		svc := s3.New(session.New())
+		be = s3be.New(svc, u.Host, u.Path)
+	default:
+		checkErr(fmt.Errorf("invalid scheme: %s", u.Scheme))
+	}
+
+	f := remotefile.New(be)
+
+	// Delete temp files when we're done, whatever happens.
+	defer func() {
+		err := f.Close()
+		checkErr(err)
+	}()
+
+	// Download the file, if it exists on the remote.
+	_, err = f.Get()
+	checkErr(err)
+
+	// Store the current state, to compare after edit.
+	chk1, err := f.Checksum()
+	checkErr(err)
+
+	// Edit the temp file.
 	p := f.Path()
-	fmt.Printf("editing %s\n", p)
 	cmd := exec.Command("vim", p)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Run()
 
-	fmt.Println("uploading...")
-	err = f.Put()
+	// Stop if the file wasn't changed.
+	chk2, err := f.Checksum()
 	checkErr(err)
+	if chk2 == chk1 {
+		return
+	}
 
-	fmt.Println("cleaning up...")
-	err = f.Close()
+	// Upload the temp file to replace the remote, or delete it if the temp file
+	// was deleted.
+	err = f.Put()
 	checkErr(err)
 }
 
+// checkErr exits the program if err is not nil.
 func checkErr(err error) {
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
 		os.Exit(1)
 	}
 }

--- a/file.go
+++ b/file.go
@@ -109,7 +109,11 @@ func (r *File) pathExists(p string) bool {
 
 // Checksum returns the hex-encoded SHA1 checksum of the contents of the
 // temporary file. This is used to determine whether the file has changed.
+// Returns an empty string but no error if the file doesn't exist.
 func (r *File) Checksum() (string, error) {
+	if !r.pathExists(r.Path()) {
+		return "", nil
+	}
 
 	f, err := r.fs.OpenFile(r.Path(), os.O_RDONLY, 0600)
 	if err != nil {

--- a/file_test.go
+++ b/file_test.go
@@ -93,12 +93,16 @@ func TestFileChecksum(t *testing.T) {
 		t.Fatalf("expected no error when creating tmp dir, got %q", err)
 	}
 
+	sum, err := f.Checksum()
+	assert.NoError(t, err)
+	assert.Equal(t, "", sum)
+
 	err = writeFile(fs, f.Path(), local, 0600)
 	if err != nil {
 		t.Fatalf("expected no error when writing local file, got %q", err)
 	}
 
-	sum, err := f.Checksum()
+	sum, err = f.Checksum()
 	assert.NoError(t, err)
 	assert.Equal(t, "2e3b1d2f993e7df69e9fb761f0b9434bfec2e44c", sum)
 }


### PR DESCRIPTION
This modifies the Checksum method to not consider it an error if the temp file doesn't exist, which makes it much simpler to track whether it has changed since being downloaded. It also upgrades the example program to demonstrate this pattern.